### PR TITLE
Fix 500 on fixture details page

### DIFF
--- a/app/Http/Controllers/SoccerAPI/SoccerAPIController.php
+++ b/app/Http/Controllers/SoccerAPI/SoccerAPIController.php
@@ -178,7 +178,7 @@ class SoccerAPIController extends BaseController
         $deviceType = self::getDeviceType();
         $dateFormat = self::getDateFormat();
 
-        $fixture = self::makeCall('fixture_by_id', 'participants;state;scores;lineups.player;sidelined.player;statistics.type;comments;league;season;events;venue;coaches.coach;stage;round', $fixtureId);
+        $fixture = self::makeCall('fixture_by_id', 'participants;state;scores;lineups.player;sidelined.player;statistics.type;comments;league;season;events;venue;coaches;stage;round', $fixtureId);
 
         $h2hFixtures = [];
         if (! empty($fixture->localteam_id) && ! empty($fixture->visitorteam_id)) {
@@ -874,6 +874,9 @@ class SoccerAPIController extends BaseController
 
         if (! isset($obj->reason) && isset($obj->player_id) && ! isset($obj->jersey_number)) {
             $obj->reason = $obj->category ?? $obj->description ?? '';
+            if (! isset($obj->team_id) && isset($obj->participant_id)) {
+                $obj->team_id = $obj->participant_id;
+            }
         }
 
         // Coach profile: ensure common_name and coach_id for view rendering
@@ -884,6 +887,11 @@ class SoccerAPIController extends BaseController
             if (! isset($obj->coach_id) && isset($obj->id)) {
                 $obj->coach_id = $obj->id;
             }
+        }
+
+        // Statistics: flatten nested data.value onto the stat object
+        if (! isset($obj->value) && isset($obj->type_id) && isset($obj->participant_id) && isset($obj->data->data->value)) {
+            $obj->value = $obj->data->data->value;
         }
     }
 

--- a/app/Http/Controllers/SoccerAPI/SoccerAPIController.php
+++ b/app/Http/Controllers/SoccerAPI/SoccerAPIController.php
@@ -179,7 +179,11 @@ class SoccerAPIController extends BaseController
         $dateFormat = self::getDateFormat();
 
         $fixture = self::makeCall('fixture_by_id', 'participants;state;scores;lineups.player;sidelined.player;statistics.type;comments;league;season;events;venue;coaches.coach;stage;round', $fixtureId);
-        $h2hFixtures = self::makeCall('h2h', 'participants;league;season;state;scores;round;stage', null, null, $fixture->localteam_id ?? null, $fixture->visitorteam_id ?? null);
+
+        $h2hFixtures = [];
+        if (! empty($fixture->localteam_id) && ! empty($fixture->visitorteam_id)) {
+            $h2hFixtures = self::makeCall('h2h', 'participants;league;season;state;scores;round;stage', null, null, $fixture->localteam_id, $fixture->visitorteam_id, false);
+        }
 
         return view("{$deviceType}/fixtures/fixtures_details", ['fixture' => $fixture, 'h2h_fixtures' => $h2hFixtures, 'date_format' => $dateFormat]);
     }

--- a/resources/views/desktop/fixtures/fixtures_details.blade.php
+++ b/resources/views/desktop/fixtures/fixtures_details.blade.php
@@ -598,15 +598,18 @@
                         @endif
                         @if(isset($localCoach) || isset($visitorCoach))
                             @php
-                                $localCoach->nationality = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getCountryFlag($localCoach->nationality);
-                                $visitorCoach->nationality = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getCountryFlag($visitorCoach->nationality);
-
-                                if($localCoach->nationality == "Unknown") {
-                                    Log::emergency("Missing nationality for coach with id: " . $localCoach->coach_id);
+                                if(isset($localCoach)) {
+                                    $localCoach->nationality = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getCountryFlag($localCoach->nationality);
+                                    if($localCoach->nationality == "Unknown") {
+                                        Log::emergency("Missing nationality for coach with id: " . $localCoach->coach_id);
+                                    }
                                 }
 
-                                if($visitorCoach->nationality == "Unknown") {
-                                    Log::emergency("Missing nationality for coach with id: " . $visitorCoach->coach_id);
+                                if(isset($visitorCoach)) {
+                                    $visitorCoach->nationality = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getCountryFlag($visitorCoach->nationality);
+                                    if($visitorCoach->nationality == "Unknown") {
+                                        Log::emergency("Missing nationality for coach with id: " . $visitorCoach->coach_id);
+                                    }
                                 }
                             @endphp
                         <tr style="font-weight: bold; text-align: center; background: #D3D3D3">

--- a/resources/views/desktop/fixtures/fixtures_details.blade.php
+++ b/resources/views/desktop/fixtures/fixtures_details.blade.php
@@ -254,7 +254,7 @@
                     @php
                         $stats_by_type = [];
                         foreach ($statistics as $stat) {
-                            $typeId   = $stat->data_type_id;
+                            $typeId   = $stat->type_id ?? $stat->data_type_id;
                             $devName  = strtolower(str_replace('_', '-', $stat->type->data->developer_name ?? ''));
                             $label    = \Illuminate\Support\Facades\Lang::has('statistics.' . $devName)
                                 ? trans('statistics.' . $devName)
@@ -345,9 +345,9 @@
                             foreach($lineup as $val){
                                 $val->team_id == $homeTeam->id ? $val->team = "home" : $val->team = "away";
                                 if(isset($val->player->data)) {
-                                    $player = ["player_id" => $val->player_id, "number" => $val->number, "common_name" => $val->player->data->common_name, "nationality" => $val->player->data->nationality, "stats" => $val->stats, "events" => array()];
+                                    $player = ["player_id" => $val->player_id, "number" => $val->number, "common_name" => $val->player->data->common_name ?? $val->player->data->display_name ?? '', "nationality" => $val->player->data->nationality ?? 'Unknown', "stats" => $val->stats, "events" => array()];
                                 } else {
-                                    $player = ["player_id" => $val->player_id, "number" => $val->number, "common_name" => $val->player_name, "nationality" => "Unknown", "stats" => $val->stats, "events" => array()];
+                                    $player = ["player_id" => $val->player_id, "number" => $val->number, "common_name" => $val->player_name ?? '', "nationality" => "Unknown", "stats" => $val->stats, "events" => array()];
                                 }
 
                                 if($val->stats->goals->scored != 0) {
@@ -443,9 +443,9 @@
                                 foreach($bench as $val){
                                     $val->team_id == $homeTeam->id ? $val->team = "home" : $val->team = "away";
                                     if(isset($val->player->data)) {
-                                        $player = ["player_id" => $val->player_id, "number" => $val->number, "common_name" => $val->player->data->common_name, "nationality" => $val->player->data->nationality, "stats" => $val->stats, "events" => array()];
+                                        $player = ["player_id" => $val->player_id, "number" => $val->number, "common_name" => $val->player->data->common_name ?? $val->player->data->display_name ?? '', "nationality" => $val->player->data->nationality ?? 'Unknown', "stats" => $val->stats, "events" => array()];
                                     } else {
-                                        $player = ["player_id" => $val->player_id, "number" => $val->number, "common_name" => $val->player_name, "nationality" => "Unknown", "stats" => $val->stats, "events" => array()];
+                                        $player = ["player_id" => $val->player_id, "number" => $val->number, "common_name" => $val->player_name ?? '', "nationality" => "Unknown", "stats" => $val->stats, "events" => array()];
                                     }
 
                                     if($val->stats->goals->scored != 0) {
@@ -541,7 +541,7 @@
                                 $counter_a = 0;
                                 foreach($sidelined as $val){
                                     $val->team_id == $homeTeam->id ? $val->team = "home" : $val->team = "away";
-                                    $player = array("player_id" => $val->player_id, "common_name" => $val->player->data->common_name, "nationality" => $val->player->data->nationality, "reason" => $val->reason);
+                                    $player = array("player_id" => $val->player_id, "common_name" => $val->player->data->common_name ?? $val->player->data->display_name ?? '', "nationality" => $val->player->data->nationality ?? 'Unknown', "reason" => $val->reason);
 
                                     $player['nationality'] = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getCountryFlag($player['nationality']);
 


### PR DESCRIPTION
## Summary

- Guards the H2H API call: only fires when both `localteam_id` and `visitorteam_id` are present; missing IDs previously caused an unhandled exception → 500
- Fixes the coaches block in `fixtures_details.blade.php` which accessed `$localCoach` and `$visitorCoach` unconditionally inside the `isset($localCoach) || isset($visitorCoach)` guard, causing a null dereference when only one coach was present

Closes task 2 (`tasks/2-fix-fixture-overview.md`)

## Test plan

- [ ] Visit `/fixtures/19609131` — should render without 500
- [ ] Verify fixtures with both coaches, one coach, and no coaches all display correctly
- [ ] Verify fixture without participants (no team IDs) renders gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)