### PR TITLE
Make team and away-team favourite stars clickable

### DIFF
--- a/resources/views/desktop/fixtures/fixtures_details.blade.php
+++ b/resources/views/desktop/fixtures/fixtures_details.blade.php
@@ -152,7 +152,7 @@
                     <tr>
                         <td width="49%" style="vertical-align: top"><h5><a href="{{ route("setFavoriteTeams", ["id" => $homeTeam->id]) }}"><i class="{{ $favorite_homeTeam }} fa-star fa-fw" aria-hidden="true"></i></a>&nbsp;<a href="{{ route("teamsDetails", ["id" => $homeTeam->id]) }}">{{ $homeTeam->name }}</a></h5></td>
                         <td></td>
-                        <td width="49%" style="vertical-align: top"><h5><i class="{{ $favorite_awayTeam }} fa-star fa-fw" aria-hidden="true"></i>&nbsp;<a href =" {{route("teamsDetails", ["id" => $awayTeam->id])}} ">{{ $awayTeam->name }}</a></h5></td>
+                        <td width="49%" style="vertical-align: top"><h5><a href="{{ route("setFavoriteTeams", ["id" => $awayTeam->id]) }}"><i class="{{ $favorite_awayTeam }} fa-star fa-fw" aria-hidden="true"></i></a>&nbsp;<a href="{{ route("teamsDetails", ["id" => $awayTeam->id]) }}">{{ $awayTeam->name }}</a></h5></td>
                     </tr>
                 </table>
 

--- a/resources/views/desktop/teams/teams_details.blade.php
+++ b/resources/views/desktop/teams/teams_details.blade.php
@@ -23,7 +23,7 @@
                             $favorite_team = "fas";
                         }
                     @endphp
-                    <td style="vertical-align: top"><h3><i class="{{ $favorite_team }} fa-star fa-fw fa-xs" aria-hidden="true" style="transform: translate(10%, -10%);"></i>&nbsp;{{$team->name}}</h3></td>
+                    <td style="vertical-align: top"><h3><a href="{{ route("setFavoriteTeams", ["id" => $team->id]) }}"><i class="{{ $favorite_team }} fa-star fa-fw fa-xs" aria-hidden="true" style="transform: translate(10%, -10%);"></i></a>&nbsp;{{$team->name}}</h3></td>
                 </tr>
                 @if(isset($coach))
                     <tr>


### PR DESCRIPTION
## Summary

- Wraps the star icon on the team detail page (`/teams/{id}`) in an anchor tag pointing to `setFavoriteTeams` — it was just a bare `<i>` with no click handler
- Fixes the same issue for the away-team cell in `fixtures_details.blade.php`; the home-team cell already had the link but the away-team cell did not

Closes task 3 (`tasks/3-non-clickable-favourite-team.md`)

## Test plan

- [ ] Visit `/teams/{id}` and click the star — team should be toggled in favourites
- [ ] Visit `/fixtures/{id}` and click the away-team star — should toggle as favourite
- [ ] Both home and away team stars on the fixture detail page should be clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)