### PR TITLE
Add SPORTMONKS_FOOTBALL_LOCALE support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,5 @@ MAIL_FROM_NAME="${APP_NAME}"
 # Sportmonks V3 API — get a token at https://www.sportmonks.com/register
 SPORTMONKS_FOOTBALL_API_TOKEN=
 SPORTMONKS_FOOTBALL_TIMEZONE=Europe/Amsterdam
+# Optional: pass a locale code (e.g. ar, de, fr) to receive translated API responses
+SPORTMONKS_FOOTBALL_LOCALE=

--- a/app/Http/Controllers/SoccerAPI/SoccerAPIController.php
+++ b/app/Http/Controllers/SoccerAPI/SoccerAPIController.php
@@ -478,18 +478,20 @@ class SoccerAPIController extends BaseController
         mixed $visitorteam_id = null,
         bool $abort = true
     ): mixed {
+        $localeQuery = array_filter(['locale' => config('sportmonks-football-api.locale', '')]);
+
         try {
             $resource = match ($type) {
-                'livescores' => SportmonksFootballApi::fixture()->setInclude($include ?? '')->byDate(Carbon::now()->toDateString()),
-                'livescores/now' => SportmonksFootballApi::livescore()->setInclude($include ?? '')->inplay(),
-                'leagues' => SportmonksFootballApi::league()->setInclude($include ?? '')->all(),
-                'league_by_id' => SportmonksFootballApi::league()->setInclude($include ?? '')->byId($id),
-                'standings' => SportmonksFootballApi::standing()->setInclude($include ?? '')->bySeasonId($id),
-                'fixtures_by_date' => SportmonksFootballApi::fixture()->setInclude($include ?? '')->byDate($date),
-                'fixture_by_id' => SportmonksFootballApi::fixture()->setInclude($include ?? '')->byId($id),
-                'h2h' => SportmonksFootballApi::fixture()->setInclude($include ?? '')->byHeadToHead($localteam_id, $visitorteam_id),
-                'team_by_id' => SportmonksFootballApi::team()->setInclude($include ?? '')->byId($id),
-                'topscorers' => SportmonksFootballApi::topscorer()->setInclude($include ?? '')->bySeasonId($id),
+                'livescores' => SportmonksFootballApi::fixture()->setInclude($include ?? '')->withQueries($localeQuery)->byDate(Carbon::now()->toDateString()),
+                'livescores/now' => SportmonksFootballApi::livescore()->setInclude($include ?? '')->withQueries($localeQuery)->inplay(),
+                'leagues' => SportmonksFootballApi::league()->setInclude($include ?? '')->withQueries($localeQuery)->all(),
+                'league_by_id' => SportmonksFootballApi::league()->setInclude($include ?? '')->withQueries($localeQuery)->byId($id),
+                'standings' => SportmonksFootballApi::standing()->setInclude($include ?? '')->withQueries($localeQuery)->bySeasonId($id),
+                'fixtures_by_date' => SportmonksFootballApi::fixture()->setInclude($include ?? '')->withQueries($localeQuery)->byDate($date),
+                'fixture_by_id' => SportmonksFootballApi::fixture()->setInclude($include ?? '')->withQueries($localeQuery)->byId($id),
+                'h2h' => SportmonksFootballApi::fixture()->setInclude($include ?? '')->withQueries($localeQuery)->byHeadToHead($localteam_id, $visitorteam_id),
+                'team_by_id' => SportmonksFootballApi::team()->setInclude($include ?? '')->withQueries($localeQuery)->byId($id),
+                'topscorers' => SportmonksFootballApi::topscorer()->setInclude($include ?? '')->withQueries($localeQuery)->bySeasonId($id),
                 default => [],
             };
         } catch (\Exception $e) {
@@ -940,8 +942,10 @@ class SoccerAPIController extends BaseController
 
     private static function fetchSeasonFixtures(int|string $seasonId): array
     {
+        $localeQuery = array_filter(['locale' => config('sportmonks-football-api.locale', '')]);
+
         try {
-            $response = SportmonksFootballApi::schedule()->bySeasonId($seasonId);
+            $response = SportmonksFootballApi::schedule()->withQueries($localeQuery)->bySeasonId($seasonId);
         } catch (\Exception $e) {
             Log::error('Schedule API error: '.$e->getMessage());
 

--- a/config/sportmonks-football-api.php
+++ b/config/sportmonks-football-api.php
@@ -4,5 +4,6 @@ return [
     'base_url' => 'https://api.sportmonks.com/v3/',
     'api_token' => env('SPORTMONKS_FOOTBALL_API_TOKEN'),
     'timezone' => env('SPORTMONKS_FOOTBALL_TIMEZONE', 'UTC'),
+    'locale' => env('SPORTMONKS_FOOTBALL_LOCALE', ''),
     'return_type' => 'array', // array, collection, response, or dto
 ];


### PR DESCRIPTION
## Summary

- Adds `SPORTMONKS_FOOTBALL_LOCALE` env variable (documented in `.env.example`)
- Reads the locale from config and forwards it as a `locale` query parameter on every Sportmonks API call via the library's `withQueries()` helper
- When unset, behaviour is identical to before (no locale param sent)
- Supported locale codes per the Sportmonks docs: `zh`, `ja`, `ru`, `fa`, `ar`, `el`, `it`, `es`, `fr`, `hu`, `de`, `ua`, `ckb`, `kmr`

Closes task 1 (`tasks/1-add-locale-support.md`)

## Test plan

- [ ] Set `SPORTMONKS_FOOTBALL_LOCALE=de` in `.env` and visit a leagues/fixtures page — names should appear in German where the API has translations
- [ ] Leave `SPORTMONKS_FOOTBALL_LOCALE=` empty — app behaves as before (English/default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)