### PR TITLE
Remove national_team translation blocks from blade views

### DIFF
--- a/resources/views/desktop/fixtures/fixtures_by_date.blade.php
+++ b/resources/views/desktop/fixtures/fixtures_by_date.blade.php
@@ -17,20 +17,7 @@
                     $league = $fixture->league->data;
                     $homeTeam = $fixture->localTeam->data;
                     $awayTeam = $fixture->visitorTeam->data;
-                    
-                    if($homeTeam->national_team == true) {
-                        $homeTeam->name = trans("countries." . $homeTeam->name);
-                    }
-                    if($awayTeam->national_team == true) {
-                        $awayTeam->name = trans("countries." . $awayTeam->name);
-                    }
-                    
-                    if(strpos($homeTeam->name, "countries") !== false) {
-                        Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                    } elseif(strpos($awayTeam->name, "countries") !== false) {
-                        Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                    }
-                    
+
                     if(in_array($fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                         switch($fixture->time->status) {
                             case("FT_PEN"):

--- a/resources/views/desktop/leagues/leagues_details.blade.php
+++ b/resources/views/desktop/leagues/leagues_details.blade.php
@@ -52,19 +52,6 @@
                             $homeTeam = $last_fixture->localTeam->data;
                             $awayTeam = $last_fixture->visitorTeam->data;
 
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-
                             if(in_array($last_fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                                 switch($last_fixture->time->status) {
                                     case("FT_PEN"):
@@ -191,19 +178,6 @@
                             $homeTeam = $upcoming_fixture->localTeam->data;
                             $awayTeam = $upcoming_fixture->visitorTeam->data;
 
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-
                             $homeTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($homeTeam->logo_path, 16, 16);
                             $awayTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($awayTeam->logo_path, 16, 16);
                         @endphp
@@ -302,14 +276,6 @@
                             <tbody>
                                     @foreach($standing as $team)
                                         @php
-                                            if($team->team->data->national_team == true) {
-                                                $team->team_name = trans("countries." . $team->team_name);
-                                            }
-
-                                            if(strpos($team->team_name, "countries") !== false) {
-                                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->team_name) . " in " . app()->getLocale() . "/countries.php");
-                                            }
-
                                             $teamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($team->team->data->logo_path, 16, 16);
                                         @endphp
                                         <tr>
@@ -378,14 +344,6 @@
                                             $player->nationality = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getCountryFlag($player->nationality);
                                         } else {
                                             $player->nationality = "Unknown";
-                                        }
-
-                                        if($team->national_team == true) {
-                                            $team->name = trans("countries." . $team->name);
-                                        }
-
-                                        if(strpos($team->name, "countries") !== false) {
-                                            Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->name) . " in " . app()->getLocale() . "/countries.php");
                                         }
 
                                         $teamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($team->logo_path, 16, 16);

--- a/resources/views/desktop/livescores/livescores_now.blade.php
+++ b/resources/views/desktop/livescores/livescores_now.blade.php
@@ -23,20 +23,7 @@
                         $league = $livescore->league->data;
                         $homeTeam = $livescore->localTeam->data;
                         $awayTeam = $livescore->visitorTeam->data;
-                        
-                        if($homeTeam->national_team == true) {
-                            $homeTeam->name = trans("countries." . $homeTeam->name);
-                        }
-                        if($awayTeam->national_team == true) {
-                            $awayTeam->name = trans("countries." . $awayTeam->name);
-                        }
-                        
-                        if(strpos($homeTeam->name, "countries") !== false) {
-                            Log::warning("Missing translation-string for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        } elseif(strpos($awayTeam->name, "countries") !== false) {
-                            Log::warning("Missing translation-string for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-                        
+
                         if(in_array($livescore->time->status, array("LIVE", "HT", "ET", "PEN_LIVE", "AET", "BREAK"))) {
                             if($livescore->time->status == "HT") {
                                 $timeLine = "HT";

--- a/resources/views/desktop/livescores/livescores_today.blade.php
+++ b/resources/views/desktop/livescores/livescores_today.blade.php
@@ -15,20 +15,7 @@
                         $league = $livescore->league->data;
                         $homeTeam = $livescore->localTeam->data;
                         $awayTeam = $livescore->visitorTeam->data;
-                        
-                        if($homeTeam->national_team == true) {
-                            $homeTeam->name = trans("countries." . $homeTeam->name);
-                        }
-                        if($awayTeam->national_team == true) {
-                            $awayTeam->name = trans("countries." . $awayTeam->name);
-                        }
-                        
-                        if(strpos($homeTeam->name, "countries") !== false) {
-                            Log::critical("Missing translation-string for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        } elseif(strpos($awayTeam->name, "countries") !== false) {
-                            Log::critical("Missing translation-string for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-                        
+
                         if(in_array($livescore->time->status,  array("FT", "AET", "FT_PEN"))) {
                             switch($livescore->time->status) {
                                 case("FT_PEN"):

--- a/resources/views/desktop/teams/teams_details.blade.php
+++ b/resources/views/desktop/teams/teams_details.blade.php
@@ -9,14 +9,6 @@
                 </tr>
                 <tr>
                     @php
-                        if($team->national_team == true) {
-                            $team->name = trans("countries." . $team->name);
-                        }
-                        
-                        if(strpos($team->name, "countries") !== false) {
-                            Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-
                         $favorite_teams = \App\Http\Controllers\Filebase\FilebaseController::getField('favorite_teams');
                         $favorite_team = "far";
                         if (in_array($team->id, $favorite_teams)) {
@@ -57,20 +49,7 @@
                             $league = $last_fixture->league->data;
                             $homeTeam = $last_fixture->localTeam->data;
                             $awayTeam = $last_fixture->visitorTeam->data;
-                            
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-                            
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-                            
+
                             if(in_array($last_fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                                 switch($last_fixture->time->status) {
                                     case("FT_PEN"):
@@ -195,19 +174,6 @@
                             $league = $upcoming_fixture->league->data;
                             $homeTeam = $upcoming_fixture->localTeam->data;
                             $awayTeam = $upcoming_fixture->visitorTeam->data;
-                            
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-                            
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
 
                             $homeTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($homeTeam->logo_path, 16, 16);
                             $awayTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($awayTeam->logo_path, 16, 16);

--- a/resources/views/phone/fixtures/fixtures_by_date.blade.php
+++ b/resources/views/phone/fixtures/fixtures_by_date.blade.php
@@ -17,20 +17,7 @@
                     $league = $fixture->league->data;
                     $homeTeam = $fixture->localTeam->data;
                     $awayTeam = $fixture->visitorTeam->data;
-                    
-                    if($homeTeam->national_team == true) {
-                        $homeTeam->name = trans("countries." . $homeTeam->name);
-                    }
-                    if($awayTeam->national_team == true) {
-                        $awayTeam->name = trans("countries." . $awayTeam->name);
-                    }
-                    
-                    if(strpos($homeTeam->name, "countries") !== false) {
-                        Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                    } elseif(strpos($awayTeam->name, "countries") !== false) {
-                        Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                    }
-                    
+
                     if(in_array($fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                         switch($fixture->time->status) {
                             case("FT_PEN"):

--- a/resources/views/phone/leagues/leagues_details.blade.php
+++ b/resources/views/phone/leagues/leagues_details.blade.php
@@ -52,19 +52,6 @@
                             $homeTeam = $last_fixture->localTeam->data;
                             $awayTeam = $last_fixture->visitorTeam->data;
 
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-
                             if(in_array($last_fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                                 switch($last_fixture->time->status) {
                                     case("FT_PEN"):
@@ -191,19 +178,6 @@
                             $homeTeam = $upcoming_fixture->localTeam->data;
                             $awayTeam = $upcoming_fixture->visitorTeam->data;
 
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-
                             $homeTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($homeTeam->logo_path, 16, 16);
                             $awayTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($awayTeam->logo_path, 16, 16);
                         @endphp
@@ -298,14 +272,6 @@
                             <tbody>
                                 @foreach($standing as $team)
                                     @php
-                                        if($team->team->data->national_team == true) {
-                                            $team->team_name = trans("countries." . $team->team_name);
-                                        }
-
-                                        if(strpos($team->team_name, "countries") !== false) {
-                                            Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->team_name) . " in " . app()->getLocale() . "/countries.php");
-                                        }
-
                                         $teamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($team->team->data->logo_path, 16, 16);
                                     @endphp
                                     <tr>
@@ -344,14 +310,6 @@
                                             $player->nationality = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getCountryFlag($player->nationality);
                                         } else {
                                             $player->nationality = "Unknown";
-                                        }
-
-                                        if($team->national_team == true) {
-                                            $team->name = trans("countries." . $team->name);
-                                        }
-
-                                        if(strpos($team->name, "countries") !== false) {
-                                            Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->name) . " in " . app()->getLocale() . "/countries.php");
                                         }
 
                                         $teamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($team->logo_path, 16, 16);

--- a/resources/views/phone/livescores/livescores_now.blade.php
+++ b/resources/views/phone/livescores/livescores_now.blade.php
@@ -23,20 +23,7 @@
                         $league = $livescore->league->data;
                         $homeTeam = $livescore->localTeam->data;
                         $awayTeam = $livescore->visitorTeam->data;
-                        
-                        if($homeTeam->national_team == true) {
-                            $homeTeam->name = trans("countries." . $homeTeam->name);
-                        }
-                        if($awayTeam->national_team == true) {
-                            $awayTeam->name = trans("countries." . $awayTeam->name);
-                        }
-                        
-                        if(strpos($homeTeam->name, "countries") !== false) {
-                            Log::warning("Missing translation-string for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        } elseif(strpos($awayTeam->name, "countries") !== false) {
-                            Log::warning("Missing translation-string for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-                        
+
                         if(in_array($livescore->time->status, array("LIVE", "HT", "ET", "PEN_LIVE", "AET", "BREAK"))) {
                             if($livescore->time->status == "HT") {
                                 $timeLine = "HT";

--- a/resources/views/phone/livescores/livescores_today.blade.php
+++ b/resources/views/phone/livescores/livescores_today.blade.php
@@ -15,20 +15,7 @@
                         $league = $livescore->league->data;
                         $homeTeam = $livescore->localTeam->data;
                         $awayTeam = $livescore->visitorTeam->data;
-                        
-                        if($homeTeam->national_team == true) {
-                            $homeTeam->name = trans("countries." . $homeTeam->name);
-                        }
-                        if($awayTeam->national_team == true) {
-                            $awayTeam->name = trans("countries." . $awayTeam->name);
-                        }
-                        
-                        if(strpos($homeTeam->name, "countries") !== false) {
-                            Log::critical("Missing translation-string for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        } elseif(strpos($awayTeam->name, "countries") !== false) {
-                            Log::critical("Missing translation-string for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-                        
+
                         if(in_array($livescore->time->status,  array("FT", "AET", "FT_PEN"))) {
                             switch($livescore->time->status) {
                                 case("FT_PEN"):

--- a/resources/views/phone/teams/teams_details.blade.php
+++ b/resources/views/phone/teams/teams_details.blade.php
@@ -9,14 +9,6 @@
                 </tr>
                 <tr>
                     @php
-                        if($team->national_team == true) {
-                            $team->name = trans("countries." . $team->name);
-                        }
-                        
-                        if(strpos($team->name, "countries") !== false) {
-                            Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-
                         $favorite_teams = \App\Http\Controllers\Filebase\FilebaseController::getField('favorite_teams');
                         $favorite_team = "far";
                         if (in_array($team->id, $favorite_teams)) {
@@ -57,20 +49,7 @@
                             $league = $last_fixture->league->data;
                             $homeTeam = $last_fixture->localTeam->data;
                             $awayTeam = $last_fixture->visitorTeam->data;
-                            
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-                            
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-                            
+
                             if(in_array($last_fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                                 switch($last_fixture->time->status) {
                                     case("FT_PEN"):
@@ -195,19 +174,6 @@
                             $league = $upcoming_fixture->league->data;
                             $homeTeam = $upcoming_fixture->localTeam->data;
                             $awayTeam = $upcoming_fixture->visitorTeam->data;
-                            
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-                            
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
 
                             $homeTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($homeTeam->logo_path, 16, 16);
                             $awayTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($awayTeam->logo_path, 16, 16);

--- a/resources/views/tablet/fixtures/fixtures_by_date.blade.php
+++ b/resources/views/tablet/fixtures/fixtures_by_date.blade.php
@@ -17,20 +17,7 @@
                     $league = $fixture->league->data;
                     $homeTeam = $fixture->localTeam->data;
                     $awayTeam = $fixture->visitorTeam->data;
-                    
-                    if($homeTeam->national_team == true) {
-                        $homeTeam->name = trans("countries." . $homeTeam->name);
-                    }
-                    if($awayTeam->national_team == true) {
-                        $awayTeam->name = trans("countries." . $awayTeam->name);
-                    }
-                    
-                    if(strpos($homeTeam->name, "countries") !== false) {
-                        Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                    } elseif(strpos($awayTeam->name, "countries") !== false) {
-                        Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                    }
-                    
+
                     if(in_array($fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                         switch($fixture->time->status) {
                             case("FT_PEN"):

--- a/resources/views/tablet/leagues/leagues_details.blade.php
+++ b/resources/views/tablet/leagues/leagues_details.blade.php
@@ -51,20 +51,7 @@
                         @php
                             $homeTeam = $last_fixture->localTeam->data;
                             $awayTeam = $last_fixture->visitorTeam->data;
-                            
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-                            
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-                            
+
                             if(in_array($last_fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                                 switch($last_fixture->time->status) {
                                     case("FT_PEN"):
@@ -191,19 +178,6 @@
                             $homeTeam = $upcoming_fixture->localTeam->data;
                             $awayTeam = $upcoming_fixture->visitorTeam->data;
                             
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-                            
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-
                             $homeTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($homeTeam->logo_path, 16, 16);
                             $awayTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($awayTeam->logo_path, 16, 16);
                         @endphp
@@ -302,14 +276,6 @@
                             <tbody>
                                     @foreach($standing as $team)
                                         @php
-                                            if($team->team->data->national_team == true) {
-                                                $team->team_name = trans("countries." . $team->team_name);
-                                            }
-                                            
-                                            if(strpos($team->team_name, "countries") !== false) {
-                                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->team_name) . " in " . app()->getLocale() . "/countries.php");
-                                            }
-
                                             $teamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($team->team->data->logo_path, 16, 16);
                                         @endphp
                                         <tr>
@@ -380,14 +346,6 @@
                                             $player->nationality = "Unknown";
                                         }
                                         
-                                        if($team->national_team == true) {
-                                            $team->name = trans("countries." . $team->name);
-                                        }
-                                        
-                                        if(strpos($team->name, "countries") !== false) {
-                                            Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->name) . " in " . app()->getLocale() . "/countries.php");
-                                        }
-
                                         $teamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($team->logo_path, 16, 16);
                                     @endphp
                                     <td scope="row"><img src="/images/flags/shiny/16/{{$player->nationality}}.png" alt="countryflag">&nbsp;{{$player->common_name}}</td>

--- a/resources/views/tablet/livescores/livescores_now.blade.php
+++ b/resources/views/tablet/livescores/livescores_now.blade.php
@@ -23,20 +23,7 @@
                         $league = $livescore->league->data;
                         $homeTeam = $livescore->localTeam->data;
                         $awayTeam = $livescore->visitorTeam->data;
-                        
-                        if($homeTeam->national_team == true) {
-                            $homeTeam->name = trans("countries." . $homeTeam->name);
-                        }
-                        if($awayTeam->national_team == true) {
-                            $awayTeam->name = trans("countries." . $awayTeam->name);
-                        }
-                        
-                        if(strpos($homeTeam->name, "countries") !== false) {
-                            Log::warning("Missing translation-string for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        } elseif(strpos($awayTeam->name, "countries") !== false) {
-                            Log::warning("Missing translation-string for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-                        
+
                         if(in_array($livescore->time->status, array("LIVE", "HT", "ET", "PEN_LIVE", "AET", "BREAK"))) {
                             if($livescore->time->status == "HT") {
                                 $timeLine = "HT";

--- a/resources/views/tablet/livescores/livescores_today.blade.php
+++ b/resources/views/tablet/livescores/livescores_today.blade.php
@@ -15,20 +15,7 @@
                         $league = $livescore->league->data;
                         $homeTeam = $livescore->localTeam->data;
                         $awayTeam = $livescore->visitorTeam->data;
-                        
-                        if($homeTeam->national_team == true) {
-                            $homeTeam->name = trans("countries." . $homeTeam->name);
-                        }
-                        if($awayTeam->national_team == true) {
-                            $awayTeam->name = trans("countries." . $awayTeam->name);
-                        }
-                        
-                        if(strpos($homeTeam->name, "countries") !== false) {
-                            Log::critical("Missing translation-string for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        } elseif(strpos($awayTeam->name, "countries") !== false) {
-                            Log::critical("Missing translation-string for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-                        
+
                         if(in_array($livescore->time->status,  array("FT", "AET", "FT_PEN"))) {
                             switch($livescore->time->status) {
                                 case("FT_PEN"):

--- a/resources/views/tablet/teams/teams_details.blade.php
+++ b/resources/views/tablet/teams/teams_details.blade.php
@@ -9,14 +9,6 @@
                 </tr>
                 <tr>
                     @php
-                        if($team->national_team == true) {
-                            $team->name = trans("countries." . $team->name);
-                        }
-                        
-                        if(strpos($team->name, "countries") !== false) {
-                            Log::critical("Missing country translation for: " . str_replace("countries.", "", $team->name) . " in " . app()->getLocale() . "/countries.php");
-                        }
-
                         $favorite_teams = \App\Http\Controllers\Filebase\FilebaseController::getField('favorite_teams');
                         $favorite_team = "far";
                         if (in_array($team->id, $favorite_teams)) {
@@ -57,20 +49,7 @@
                             $league = $last_fixture->league->data;
                             $homeTeam = $last_fixture->localTeam->data;
                             $awayTeam = $last_fixture->visitorTeam->data;
-                            
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-                            
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
-                            
+
                             if(in_array($last_fixture->time->status,  array("FT", "AET", "FT_PEN"))) {
                                 switch($last_fixture->time->status) {
                                     case("FT_PEN"):
@@ -195,19 +174,6 @@
                             $league = $upcoming_fixture->league->data;
                             $homeTeam = $upcoming_fixture->localTeam->data;
                             $awayTeam = $upcoming_fixture->visitorTeam->data;
-                            
-                            if($homeTeam->national_team == true) {
-                                $homeTeam->name = trans("countries." . $homeTeam->name);
-                            }
-                            if($awayTeam->national_team == true) {
-                                $awayTeam->name = trans("countries." . $awayTeam->name);
-                            }
-                            
-                            if(strpos($homeTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $homeTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            } elseif(strpos($awayTeam->name, "countries") !== false) {
-                                Log::critical("Missing country translation for: " . str_replace("countries.", "", $awayTeam->name) . " in " . app()->getLocale() . "/countries.php");
-                            }
 
                             $homeTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($homeTeam->logo_path, 16, 16);
                             $awayTeamLogo = \App\Http\Controllers\SoccerAPI\SoccerAPIController::getTeamLogo($awayTeam->logo_path, 16, 16);


### PR DESCRIPTION
## Summary

- Removes `national_team` checks that translated team names via `trans("countries." . $team->name)` from all blade views
- Removes the associated `strpos(..., "countries")` logging blocks (`Log::critical` / `Log::warning`) that detected missing translations
- Affects livescores (now/today), fixtures (by_date), teams details, and leagues details views across desktop, phone, and tablet layouts (15 files total)

## Test plan

- [ ] Livescores page loads without errors for both live and today views
- [ ] Fixtures by date page renders correctly
- [ ] Team details page renders correctly
- [ ] League details page renders correctly (last fixtures, upcoming fixtures, standings, topscorers tabs)
- [ ] Verify no `national_team` references remain in any modified blade view

🤖 Generated with [Claude Code](https://claude.com/claude-code)